### PR TITLE
embedded smart app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -109,6 +109,11 @@
       "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.8.1.tgz",
       "integrity": "sha512-dEv1n+IFtlvLQ8/FsTOtBCC1aNT4B5abE8ODF5wk2tpWnjvgGNRMvHCeJGbVHjFfer4h8MH2w9c2/6eoJHclMg=="
     },
+    "@sindresorhus/is": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
+      "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
+    },
     "abab": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
@@ -182,6 +187,22 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/address/-/address-1.0.3.tgz",
       "integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg=="
+    },
+    "aggregate-error": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-1.0.0.tgz",
+      "integrity": "sha1-iINE2tAiCnLjr1CQYRf0h3GSX6w=",
+      "requires": {
+        "clean-stack": "1.3.0",
+        "indent-string": "3.2.0"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+        }
+      }
     },
     "ajv": {
       "version": "5.5.2",
@@ -1873,6 +1894,60 @@
         "unset-value": "1.0.0"
       }
     },
+    "cacheable-request": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
+      "integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
+      "requires": {
+        "clone-response": "1.0.2",
+        "get-stream": "3.0.0",
+        "http-cache-semantics": "3.8.1",
+        "keyv": "3.0.0",
+        "lowercase-keys": "1.0.0",
+        "normalize-url": "2.0.1",
+        "responselike": "1.0.2"
+      },
+      "dependencies": {
+        "lowercase-keys": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+        },
+        "normalize-url": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
+          "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
+          "requires": {
+            "prepend-http": "2.0.0",
+            "query-string": "5.1.1",
+            "sort-keys": "2.0.0"
+          }
+        },
+        "prepend-http": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
+        },
+        "query-string": {
+          "version": "5.1.1",
+          "resolved": "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+          "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+          "requires": {
+            "decode-uri-component": "0.2.0",
+            "object-assign": "4.1.1",
+            "strict-uri-encode": "1.1.0"
+          }
+        },
+        "sort-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+          "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+          "requires": {
+            "is-plain-obj": "1.1.0"
+          }
+        }
+      }
+    },
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
@@ -2147,6 +2222,11 @@
         }
       }
     },
+    "clean-stack": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-1.3.0.tgz",
+      "integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE="
+    },
     "cli-boxes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
@@ -2197,6 +2277,14 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+    },
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "requires": {
+        "mimic-response": "1.0.1"
+      }
     },
     "co": {
       "version": "4.6.0",
@@ -2854,6 +2942,14 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "requires": {
+        "mimic-response": "1.0.1"
+      }
     },
     "deep-equal": {
       "version": "1.0.1",
@@ -4294,6 +4390,15 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
+    "from2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
+      }
+    },
     "fs": {
       "version": "0.0.1-security",
       "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
@@ -5040,6 +5145,19 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
+    "has-symbol-support-x": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
+    },
+    "has-to-string-tag-x": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+      "requires": {
+        "has-symbol-support-x": "1.4.2"
+      }
+    },
     "has-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
@@ -5260,6 +5378,11 @@
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
+    },
+    "http-cache-semantics": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+      "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
     },
     "http-deceiver": {
       "version": "1.2.7",
@@ -5599,6 +5722,15 @@
         "intl-messageformat": "2.2.0"
       }
     },
+    "into-stream": {
+      "version": "3.1.0",
+      "resolved": "http://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+      "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
+      "requires": {
+        "from2": "2.3.0",
+        "p-is-promise": "1.1.0"
+      }
+    },
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -5838,6 +5970,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+    },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -6115,6 +6252,15 @@
       "integrity": "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
       "requires": {
         "handlebars": "4.0.11"
+      }
+    },
+    "isurl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+      "requires": {
+        "has-to-string-tag-x": "1.4.1",
+        "is-object": "1.0.1"
       }
     },
     "jest": {
@@ -6730,6 +6876,11 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
     },
+    "json-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
+    },
     "json-loader": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
@@ -6959,10 +7110,24 @@
       "resolved": "https://registry.npmjs.org/keyboard-key/-/keyboard-key-1.0.2.tgz",
       "integrity": "sha512-05cjQmw4ss/YuY2utmVim0wywDyBZGUivo8siLPkWinwGWtKlO8/4RGbPUqNycwlD3u/3D15eNRjnNAyaTDs8g=="
     },
+    "keycloak-js": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-4.6.0.tgz",
+      "integrity": "sha512-aToMU1KkDuM5VU3nr+cB9gJMmXHH5GQ52wXjg3LhCw6L6YurZh9NfMuWWZ5u/OMhYRhyI1lzWN7u5gcox7hkgw==",
+      "dev": true
+    },
     "keypair": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/keypair/-/keypair-1.0.1.tgz",
       "integrity": "sha1-dgNxknCvtlZO04oiCHoG/Jqk6hs="
+    },
+    "keyv": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
+      "integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
+      "requires": {
+        "json-buffer": "3.0.0"
+      }
     },
     "killable": {
       "version": "1.0.0",
@@ -7129,10 +7294,20 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+    },
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+    },
+    "lodash.clone": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+      "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
     },
     "lodash.cond": {
       "version": "4.5.2",
@@ -7149,10 +7324,45 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
     },
+    "lodash.fill": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.fill/-/lodash.fill-3.4.0.tgz",
+      "integrity": "sha1-o8dK5kDQU63w3CB5+HIHiOi/74U="
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
+    "lodash.intersection": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.intersection/-/lodash.intersection-4.4.0.tgz",
+      "integrity": "sha1-ChG6Yx0OlcI8fy9Mu5ppLtF45wU="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
+    },
+    "lodash.merge": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+    },
+    "lodash.omit": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
+    },
+    "lodash.partialright": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.partialright/-/lodash.partialright-4.2.1.tgz",
+      "integrity": "sha1-ATDYDoM2MmTUAHTzKbij56ihzEs="
+    },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
     },
     "lodash.startcase": {
       "version": "4.4.0",
@@ -7190,6 +7400,11 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
       "integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po="
+    },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "longest": {
       "version": "1.0.1",
@@ -7442,6 +7657,11 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -7611,6 +7831,40 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
+    },
+    "node-jose": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-jose/-/node-jose-1.1.0.tgz",
+      "integrity": "sha512-Ux5MDElyiAlBQyOdFcwznK2TWMJbG8ZUfIZ28UtBvTB/VUz5HA/1WJV7s+YCah5NilPhkMkNi6xjnFRI+MQAVg==",
+      "requires": {
+        "base64url": "3.0.0",
+        "es6-promise": "4.2.5",
+        "lodash.assign": "4.2.0",
+        "lodash.clone": "4.5.0",
+        "lodash.fill": "3.4.0",
+        "lodash.flatten": "4.4.0",
+        "lodash.intersection": "4.4.0",
+        "lodash.merge": "4.6.1",
+        "lodash.omit": "4.5.0",
+        "lodash.partialright": "4.2.1",
+        "lodash.pick": "4.4.0",
+        "lodash.uniq": "4.5.0",
+        "long": "4.0.0",
+        "node-forge": "0.7.6",
+        "uuid": "3.3.2"
+      },
+      "dependencies": {
+        "es6-promise": {
+          "version": "4.2.5",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
+          "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg=="
+        },
+        "node-forge": {
+          "version": "0.7.6",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
+          "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
+        }
+      }
     },
     "node-libs-browser": {
       "version": "2.1.0",
@@ -7812,6 +8066,14 @@
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
     },
+    "oidc-token-hash": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-3.0.1.tgz",
+      "integrity": "sha512-oLnVSEcNZkw01sB5aFR+2iJmW4oyC1PIMJmd3FMBGDuPTy5ZtEuX5WNhKMRarJIMOq8NiOwIB6eJB9AhgYwBTg==",
+      "requires": {
+        "base64url": "3.0.0"
+      }
+    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -7839,6 +8101,69 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "requires": {
         "mimic-fn": "1.2.0"
+      }
+    },
+    "openid-client": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-2.4.5.tgz",
+      "integrity": "sha512-TmQQF7mOiYZsxX4kaQbrN06SXZ31UR5m4ur6sjM+VhaIuF79lqHe7uLmmt/NGVBIQojox6a4eilQ8DQDEQv31Q==",
+      "requires": {
+        "base64url": "3.0.0",
+        "got": "8.3.2",
+        "lodash": "4.17.11",
+        "lru-cache": "4.1.3",
+        "node-jose": "1.1.0",
+        "oidc-token-hash": "3.0.1",
+        "p-any": "1.1.0"
+      },
+      "dependencies": {
+        "got": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
+          "integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
+          "requires": {
+            "@sindresorhus/is": "0.7.0",
+            "cacheable-request": "2.1.4",
+            "decompress-response": "3.3.0",
+            "duplexer3": "0.1.4",
+            "get-stream": "3.0.0",
+            "into-stream": "3.1.0",
+            "is-retry-allowed": "1.1.0",
+            "isurl": "1.0.0",
+            "lowercase-keys": "1.0.1",
+            "mimic-response": "1.0.1",
+            "p-cancelable": "0.4.1",
+            "p-timeout": "2.0.1",
+            "pify": "3.0.0",
+            "safe-buffer": "5.1.2",
+            "timed-out": "4.0.1",
+            "url-parse-lax": "3.0.0",
+            "url-to-options": "1.0.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        },
+        "prepend-http": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
+        },
+        "url-parse-lax": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+          "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+          "requires": {
+            "prepend-http": "2.0.0"
+          }
+        }
       }
     },
     "opn": {
@@ -7909,10 +8234,28 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
+    "p-any": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-any/-/p-any-1.1.0.tgz",
+      "integrity": "sha512-Ef0tVa4CZ5pTAmKn+Cg3w8ABBXh+hHO1aV8281dKOoUHfX+3tjG2EaFcC+aZyagg9b4EYGsHEjz21DnEE8Og2g==",
+      "requires": {
+        "p-some": "2.0.1"
+      }
+    },
+    "p-cancelable": {
+      "version": "0.4.1",
+      "resolved": "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+      "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ=="
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
+    "p-is-promise": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
     },
     "p-limit": {
       "version": "1.3.0",
@@ -7934,6 +8277,22 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
       "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA=="
+    },
+    "p-some": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/p-some/-/p-some-2.0.1.tgz",
+      "integrity": "sha1-Zdh8ixVO289SIdFnd4ttLhUPbwY=",
+      "requires": {
+        "aggregate-error": "1.0.0"
+      }
+    },
+    "p-timeout": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
+      "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+      "requires": {
+        "p-finally": "1.0.0"
+      }
     },
     "p-try": {
       "version": "1.0.0",
@@ -10214,6 +10573,14 @@
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
     },
+    "responselike": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "requires": {
+        "lowercase-keys": "1.0.1"
+      }
+    },
     "restore-cursor": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
@@ -11738,6 +12105,11 @@
       "requires": {
         "prepend-http": "1.0.4"
       }
+    },
+    "url-to-options": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
     },
     "use": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "jsrsasign": "^8.0.12",
     "keypair": "^1.0.1",
     "merge": "^1.2.1",
+    "openid-client": "^2.4.5",
     "popper.js": "^1.14.4",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
@@ -38,6 +39,7 @@
   },
   "devDependencies": {
     "fs": "0.0.1-security",
-    "jju": "^1.4.0"
+    "jju": "^1.4.0",
+    "keycloak-js": "^4.6.0"
   }
 }

--- a/src/components/DisplayBox.js
+++ b/src/components/DisplayBox.js
@@ -7,7 +7,7 @@ import Text from 'terra-text';
 import cx from 'classnames';
 import PropTypes from 'prop-types';
 import axios from 'axios';
-
+import SMARTBox from './SMARTBox';
 
 const propTypes = {
     /**
@@ -45,9 +45,10 @@ export default class DisplayBox extends Component{
         this.renderSource = this.renderSource.bind(this);
         this.modifySmartLaunchUrls = this.modifySmartLaunchUrls.bind(this);
         this.retrieveLaunchContext = this.retrieveLaunchContext.bind(this);
-
+        this.exitSmart = this.exitSmart.bind(this);
         this.state={
-            value: ""
+            value: "",
+            smartLink: ""
         };
     }
   /**
@@ -81,6 +82,9 @@ export default class DisplayBox extends Component{
     e.preventDefault();
   }
 
+  exitSmart(e) {
+    this.setState({"smartLink":""});
+  }
   /**
    * Open the absolute or SMART link in a new tab and display an error if a SMART link does not have
    * appropriate launch context if used against a secured FHIR endpoint.
@@ -94,7 +98,7 @@ export default class DisplayBox extends Component{
         // TODO: Create an error modal to display for SMART link that cannot be launched securely
         return;
       }
-      window.open(link.url, '_blank');
+      this.setState({"smartLink":link.url});
     }
   }
 
@@ -122,8 +126,8 @@ export default class DisplayBox extends Component{
           } else {
             linkCopy.url += '&';
           }
-          linkCopy.url += `fhirServiceUrl=${this.props.fhirServerUrl}`;
-          linkCopy.url += `&patientId=${this.props.patientId}`;
+          //linkCopy.url += `fhirServiceUrl=${this.props.fhirServerUrl}`;
+          //linkCopy.url += `&patientId=${this.props.patientId}`;
         }
         return linkCopy;
       });
@@ -220,6 +224,7 @@ retrieveLaunchContext(link, accessToken, patientId, fhirBaseUrl) {
         );
       }
     render() {
+      console.log(this.state.smartLink);
         const indicators = {
             info: 0,
             warning: 1,
@@ -295,6 +300,13 @@ retrieveLaunchContext(link, accessToken, patientId, fhirBaseUrl) {
           }
 
           if (renderedCards.length === 0) { return <div><div className='decision-card alert-warning'>No Cards</div></div>; }
-          return <div>{renderedCards}</div>;
+          return <div>
+                  <div>
+                  {renderedCards}
+                  </div>
+                  <div>
+                    <SMARTBox link={this.state.smartLink} exitSmart={this.exitSmart}/>
+                  </div>
+                </div>;
         }
       }

--- a/src/components/InputBox.js
+++ b/src/components/InputBox.js
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-import { connect } from 'react-redux';
 
 
 export default class InputBox extends Component {

--- a/src/components/SMARTBox.js
+++ b/src/components/SMARTBox.js
@@ -1,0 +1,49 @@
+import React, {Component} from 'react';
+import './smart.css';
+export default class SMARTBox extends Component {
+    constructor(props){
+        super(props);
+        this.state={
+            minimized: true
+        };
+
+        this.minimizeSmart = this.minimizeSmart.bind(this);
+    }
+
+    minimizeSmart(){
+        this.setState({"minimized":!this.state.minimized})
+    }
+
+
+    render() {
+
+        return (
+            <div>
+                {this.props.link?this.state.minimized?
+                            <div className="smartBox">
+                            <div className="smartHeader">
+                            <button 
+                            className="smartExit"
+                            onClick={this.props.exitSmart}>X</button>
+                            <button 
+                            className="smartMinimize"
+                            onClick={this.minimizeSmart}>-</button>
+                            </div>
+                            
+                            <iframe src={this.props.link}></iframe>
+
+                            </div>
+                            :
+                            <div>
+                                <a 
+                                onClick={this.minimizeSmart}
+                                className="minimizedFrame">Smart App</a>
+                            </div>
+                            :
+                            ""
+            }
+            </div>
+
+        )
+    }
+}

--- a/src/components/smart.css
+++ b/src/components/smart.css
@@ -1,0 +1,44 @@
+.smartBox{
+    position: absolute;
+    left:15%;
+    top:15%;
+    margin-bottom:50px;
+    display:block;
+    height:70%;
+    width:70%;
+
+    font-size:14px;
+    background-color: white;
+}
+
+iframe{
+    width:100%;
+    height:100%;
+}
+
+.smartExit{
+
+    border-style: solid;
+    border-color:gray;
+    border-width: 2px 2px 2px 2px;
+    position:absolute;
+    right:-25px;
+    width:27px;
+
+}
+
+.smartMinimize{
+    position:absolute;
+    right:-25px;
+    border: 2px solid gray;
+    width:27px;
+    top:21px;
+}
+
+.minimizedFrame{
+    border-style: solid;
+    border-color: blue gray gray gray;
+    border-width: 2px;
+    padding: 2px;
+    margin-left: 10px;
+}

--- a/src/containers/RequestBuilder.js
+++ b/src/containers/RequestBuilder.js
@@ -33,15 +33,14 @@ export default class RequestBuilder extends Component{
             oauth:false,
             loading:false,
             logs:[],
-            keypair:KEYUTIL.generateKeypair('RSA',2048)
+            keypair:null
         };
         this.validateMap={
             age:(foo=>{return isNaN(foo)}),
             gender:(foo=>{return foo!=="male" && foo!=="female"}),
             code:(foo=>{return !foo.match(/^[a-z0-9]+$/i)})
         };
-        console.log(this.state.keypair);
-
+ 
 
 
 
@@ -50,8 +49,13 @@ export default class RequestBuilder extends Component{
     this.startLoading = this.startLoading.bind(this);
     this.submit_info = this.submit_info.bind(this);
     this.consoleLog = this.consoleLog.bind(this);
-
     }
+
+  
+    componentDidMount() {
+      this.setState({keypair: KEYUTIL.generateKeypair('RSA',2048)});
+    }
+
   
     makeid() {
       var text = [];
@@ -68,7 +72,7 @@ export default class RequestBuilder extends Component{
     
       const jwkPrv2 = KEYUTIL.getJWKFromKey(this.state.keypair.prvKeyObj);
       const jwkPub2 = KEYUTIL.getJWKFromKey(this.state.keypair.pubKeyObj);
-      console.log(pubKey);
+
       const currentTime = KJUR.jws.IntDate.get('now');
       const endTime = KJUR.jws.IntDate.get('now + 1day');
       const kid = KJUR.jws.JWS.getJWKthumbprint(jwkPub2)

--- a/src/properties.json
+++ b/src/properties.json
@@ -1,4 +1,5 @@
 {
   "realm": "ClientFhirServer",
-  "client": "app-login"
+  "client": "app-login",
+  "auth": "http://localhost:8180/auth"
 }


### PR DESCRIPTION
This PR makes the `smart app` link in the returned cards launch in the request generator as an `iframe`.  The issue of authorization can be solved by altering the settings in the Keycloak realm.  Using the following settings in `Content-Security-Policy`, located under `Security Defenses` will allow the redirection to the authorization page to take place in the `iframe`:

`frame-src 'self'; frame-ancestors http://localhost:3000; object-src 'none';`

Making a request with the current request generator will return an error, since the patients in the fhir database do not have a `name` value.  Adding a patient with a name and changing the patient id in the request made by the request generator to that patient will result in a successful displaying of the SMART app.  