### PR TITLE
[193] made inputs controlled, fed in by parent

### DIFF
--- a/src/components/DropdownInput.js
+++ b/src/components/DropdownInput.js
@@ -38,7 +38,7 @@ export default class DropdownInput extends Component {
 
 
   render() {
-    const { currentValue } = this.state
+    const { currentValue } = this.props
     if(currentValue){
         blackBorder = "blackBorder";
     }else{

--- a/src/components/DropdownState.js
+++ b/src/components/DropdownState.js
@@ -60,7 +60,7 @@ let blackBorder = "blackBorder";
 export default class DropdownState extends Component {
   constructor(props){
     super(props);
-    this.state = { currentValue: ""}
+    this.state = { currentValue: "MA"}
   };
 
   handleChange = (e, { value }) => {
@@ -69,7 +69,7 @@ export default class DropdownState extends Component {
   }
 
   render() {
-    const { currentValue } = this.state
+    const { currentValue } = this.props;
     if(currentValue){
         blackBorder = "blackBorder";
     }else{
@@ -84,6 +84,7 @@ export default class DropdownState extends Component {
         selection
         fluid
         onChange={this.handleChange}
+        value={currentValue}
       />
     )
   }

--- a/src/components/InputBox.js
+++ b/src/components/InputBox.js
@@ -22,7 +22,7 @@ export default class InputBox extends Component {
             <input
             className={"form-control input-text " + this.props.extraClass}
             name={this.props.elementName}
-            value={this.state.value}
+            value={this.props.value}
             onChange={this.onInputChange}
 
             ></input>

--- a/src/components/Toggle.js
+++ b/src/components/Toggle.js
@@ -14,44 +14,41 @@ export default class Toggle extends Component {
     this.clickedOption1 = this.clickedOption1.bind(this);
     this.clickedOption2 = this.clickedOption2.bind(this);
     }
-
-
     clickedOption1(){
-        if(this.state.option1class==="genderBlockMaleUnselected"){
-            this.setState({option1class : "genderBlockMaleSelected"})
+        if(this.props.value!==this.props.options.option1.value){
             this.props.updateCB(this.props.elementName, this.props.options.option1.value);
-
-            if(this.state.option2class==="genderBlockFemaleSelected"){
-                this.setState({option2class : "genderBlockFemaleUnselected"})
-            }
         }else{
-            this.setState({option1class: "genderBlockMaleUnselected"})
             this.props.updateCB(this.props.elementName, "");
         }
 
     }
-
     clickedOption2(){
-        if(this.state.option2class==="genderBlockFemaleUnselected"){
-            this.setState({option2class : "genderBlockFemaleSelected"})
+        if(this.props.value!==this.props.options.option2.value){
             this.props.updateCB(this.props.elementName, this.props.options.option2.value);
-            if(this.state.option1class==="genderBlockMaleSelected"){
-                this.setState({option1class : "genderBlockMaleUnselected"})
-            }
         }else{
-            this.setState({option2class: "genderBlockFemaleUnselected"})
             this.props.updateCB(this.props.elementName, "");
         }
 
     }
     render() {
+        let option1class, option2class = "";
+        if(this.props.value==this.props.options.option1.value) {
+            option1class = "genderBlockMaleSelected";
+            option2class = "genderBlockFemaleUnselected"
+        }else if(this.props.value==this.props.options.option2.value){
+            option1class = "genderBlockMaleUnselected";
+            option2class = "genderBlockFemaleSelected";
+        }else{
+            option1class = "genderBlockMaleUnselected";
+            option2class = "genderBlockFemaleUnselected";
+        }
         return (
             <div>
             <div
             name={this.props.elementName}
             >
-            <button onClick={this.clickedOption1} className={this.state.option1class+" genderBlockMale btn btn-class"}>{this.props.options.option1.text}</button>
-            <button onClick={this.clickedOption2} className={this.state.option2class+" genderBlockFemale btn btn-class"}>{this.props.options.option2.text}</button>
+            <button onClick={this.clickedOption1} className={option1class+" genderBlockMale btn btn-class"}>{this.props.options.option1.text}</button>
+            <button onClick={this.clickedOption2} className={option2class+" genderBlockFemale btn btn-class"}>{this.props.options.option2.text}</button>
             </div>
             </div>
         )

--- a/src/containers/RequestBuilder.js
+++ b/src/containers/RequestBuilder.js
@@ -23,9 +23,10 @@ export default class RequestBuilder extends Component{
     constructor(props){
         super(props);
         this.state = { 
-            age: null,
+            age: "",
             gender: null,
             code: null,
+            codeSystem:null,
             patientState: null,
             practitionerState: null,
             response:null,
@@ -45,6 +46,7 @@ export default class RequestBuilder extends Component{
     this.startLoading = this.startLoading.bind(this);
     this.submit_info = this.submit_info.bind(this);
     this.consoleLog = this.consoleLog.bind(this);
+    this.setDara = this.setDara.bind(this);
     }
 
   
@@ -52,6 +54,15 @@ export default class RequestBuilder extends Component{
       this.setState({keypair: KEYUTIL.generateKeypair('RSA',2048)});
     }
 
+    setDara() {
+        this.setState({age: 79,
+            gender: "female",
+            code: "E0424",
+            codeSystem:"https://bluebutton.cms.gov/resources/codesystem/hcpcs",
+            patientState: "MA",
+            practitionerState: "MA"});
+
+    }
     makeid() {
       var text = [];
       var possible = "---ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
@@ -272,6 +283,7 @@ export default class RequestBuilder extends Component{
         return (
             <div>
             <div className="form-group container left-form">
+            <button className="dara-button btn btn-class" onClick={this.setDara}>Dara</button>
                 {Object.keys(this.validateMap)
                 .map((key) => {
 
@@ -286,6 +298,7 @@ export default class RequestBuilder extends Component{
                           Gender
                         </div>
                         <Toggle
+                        value = {this.state.gender}
                         elementName={key}
                         updateCB={this.updateStateElement}
                         options={options}
@@ -300,6 +313,7 @@ export default class RequestBuilder extends Component{
                           Code
                         </div>
                         <DropdownInput
+                            currentValue={this.state.code}
                             elementName={key}
                             updateCB={this.updateStateElement}
                             />
@@ -312,6 +326,7 @@ export default class RequestBuilder extends Component{
                           Age
                         </div>
                         <InputBox
+                            value={this.state.age}
                             elementName={key}
                             updateCB={this.updateStateElement}
                             extraClass={!validationResult[key] ? "error-border" : "regular-border"}/>
@@ -327,6 +342,7 @@ export default class RequestBuilder extends Component{
                   <DropdownState 
                     elementName="patientState"
                     updateCB={this.updateStateElement}
+                    currentValue={this.state.patientState}
                   />
                   </div>
                   <div className="rightStateInput">
@@ -336,6 +352,7 @@ export default class RequestBuilder extends Component{
                   <DropdownState 
                     elementName="practitionerState"
                     updateCB={this.updateStateElement}
+                    currentValue={this.state.practitionerState}
                   />
                   </div>
                 </div>

--- a/src/index.css
+++ b/src/index.css
@@ -239,3 +239,14 @@ input:not(:focus):not([value=""]):valid ~ .floating-label{
   float:left;
   margin-bottom:25px;
 }
+
+.dara-button{
+    border-width:1px 3px 3px 3px;
+    border-style: solid solid solid solid;
+    border-color: black;
+    background: linear-gradient(white,white)
+}
+.dara-button:hover{
+    background: black;
+    color: white;
+}


### PR DESCRIPTION
Aside from adding Dara, this makes the input fields controlled.  This means their value and display is controlled by the parent, in this case `RequestBuilder.js`, instead of handling it locally.  Before, changing the state of `RequestBuilder` (which contained the info that would actually get sent by a request) would not affect the input fields.  For example, changing the age to 40 in the request builders state would not show 40 in the age input.  If you submitted the form, however, it would still send with the age field populated as 40.  The changes here make it so that the inputs update when the parent state is changed instead of their own local state (since they pass back their values to the parent anyway, this doesn't change anything but the visuals).  

Also adds a "Dara" button which sets the values to be the patient Dara's info.  This just updates the state, which, due to the previously mentioned changes, changes the inputs to contain Dara's values.  