### PR TITLE
[#221]fixed absolute links using smartLink

### DIFF
--- a/src/components/DisplayBox.js
+++ b/src/components/DisplayBox.js
@@ -98,7 +98,11 @@ export default class DisplayBox extends Component{
         // TODO: Create an error modal to display for SMART link that cannot be launched securely
         return;
       }
-      this.setState({"smartLink":link.url});
+      if(link.type === "smart"){
+        this.setState({"smartLink":link.url});
+      }else{
+        window.open(link.url, '_blank');
+      }
     }
   }
 


### PR DESCRIPTION
at some point all links were being treated as smart links and being passed to `SmartBox.js` which was rendering them in an iframe, which, unsurprisingly, could not be done for the absolute CMS pdf links since the permissions on the iframe are extremely gratuitous.  

This has been changed so that non-smart links are opened in a new tab.