### PR TITLE
DMEERX-819 Fix ext-insurance usage

### DIFF
--- a/src/components/RequestBox/RequestBox.js
+++ b/src/components/RequestBox/RequestBox.js
@@ -159,7 +159,7 @@ export default class RequestBox extends Component {
     // TODO: Update for R4
     client
       .request(`DeviceRequest/${deviceRequest.id}`, {
-        resolveReferences: ["performer", "extension.0.valueReference"],
+        resolveReferences: ["performer", "insurance.0"],
         graph: false,
         flat: true,
       })


### PR DESCRIPTION
This PR is to address this JIRA ticket: 
https://jira.mitre.org/browse/DMEERX-819

It fixes the retrieval failure of DeviceRequest insurance info after removing ext-insurance extension. 

To test it:
1. Use extInsurance branch of test-ehr
2. Run the usual select patient of those DeviceRequest from the request generator
3. The check box of "Insurance" should be green