### PR TITLE
Logica fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:10-alpine
+RUN mkdir -p /home/node/app/node_modules && chown -R node:node /home/node/app
+WORKDIR /home/node/app
+COPY package*.json ./
+USER node
+RUN npm install
+COPY --chown=node:node . .
+EXPOSE 3000
+CMD [ "/home/node/app/run.sh" ]

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+echo "npm run build"
+npm run build
+echo "npm run start$VERSION"
+npm run start$VERSION

--- a/src/components/DisplayBox/DisplayBox.js
+++ b/src/components/DisplayBox/DisplayBox.js
@@ -197,14 +197,14 @@ retrieveLaunchContext(link, accessToken, patientId, fhirBaseUrl, fhirVersion) {
           parameters: launchParameters,
         },
       }).then((result) => {
-        if (result.data && Object.prototype.hasOwnProperty.call(result.data, 'launchId')) {
+        if (result.data && Object.prototype.hasOwnProperty.call(result.data, 'launch_id')) {
           if (link.url.indexOf('?') < 0) {
             link.url += '?';
           } else {
             link.url += '&';
           }
-          link.url += `launch=${result.data.launchId}`;
-          link.url += `&iss=${fhirBaseUrl}/${fhirVersion}`;
+          link.url += `launch=${result.data.launch_id}`;
+          link.url += `&iss=${fhirBaseUrl}`;
           return resolve(link);
         }
         console.error('FHIR server endpoint did not return a launch_id to launch the SMART app. See network calls to the Launch endpoint for more details');

--- a/src/components/SettingsBox/SettingsBox.js
+++ b/src/components/SettingsBox/SettingsBox.js
@@ -25,7 +25,7 @@ export default class SettingsBox extends Component {
         return (
             <div>
                 {Object.keys(headers).map((header)=>{
-                    let value = headers[header].value[this.props.version];
+                    let value = headers[header].value;
                     return <div key={header}>
                         <p className="setting-header">{headers[header].display}</p>
                         <InputBox 
@@ -34,11 +34,7 @@ export default class SettingsBox extends Component {
                             updateCB = {this.updateCB}
                             elementName = {header}/>
                     </div>
-
                 })}
-
-
-
             </div>
 
         )

--- a/src/containers/RequestBuilder.js
+++ b/src/containers/RequestBuilder.js
@@ -28,7 +28,6 @@ export default class RequestBuilder extends Component {
             loading: false,
             logs: [],
             keypair: null,
-            version: "r4",
             config: {},
             ehrUrl: headers.ehrUrl.value,
             authUrl: headers.authUrl.value,
@@ -53,7 +52,6 @@ export default class RequestBuilder extends Component {
         };
 
         this.updateStateElement = this.updateStateElement.bind(this);
-        this.updateVersionedStateElement = this.updateVersionedStateElement.bind(this)
         this.startLoading = this.startLoading.bind(this);
         this.submit_info = this.submit_info.bind(this);
         this.consoleLog = this.consoleLog.bind(this);
@@ -63,7 +61,7 @@ export default class RequestBuilder extends Component {
 
     componentDidMount() {
         this.setState({ config });
-
+        this.setState({baseUrl: config.ehr_base ? config.ehr_base : config.ehr_server})
         const callback = (keypair) => {
             this.setState({ keypair });
         }
@@ -109,17 +107,6 @@ export default class RequestBuilder extends Component {
         this.setState({ [elementName]: text });
     }
 
-    updateVersionedStateElement = (elementName, text) => {
-        this.setState(prevState => ({
-            ...prevState,
-            [elementName]: {
-                ...prevState[elementName],
-                [this.state.version]: text
-            }
-        }
-        ))
-    }
-
     onInputChange(event) {
         this.setState({ [event.target.name]: event.target.value });
     }
@@ -131,11 +118,7 @@ export default class RequestBuilder extends Component {
 
     }
 
-    getHookType(cdsUrl, fhirVersion) {
-        var url = cdsUrl.r4;
-        if (fhirVersion === "stu3") {
-            url = cdsUrl.stu3;
-        }
+    getHookType(url) {
         if (url.includes("order-review")) {
             return "order-review";
         } else if (url.includes("order-sign")) {
@@ -150,22 +133,19 @@ export default class RequestBuilder extends Component {
         this.consoleLog("Initiating form submission", types.info);
         this.setState({patient});
         
-        var hook = this.getHookType(this.state.cdsUrl, this.state.version);
-        let json_request = buildRequest(request, patient, this.state.ehrUrl, this.state.token, prefetch, this.state.version, this.state.prefetch, hook);
-        const cdsUrl = this.state.cdsUrl[this.state.version];
-        // get the base url for the EHR server by stripping the FHIR version off
-        let baseUrl = this.state.ehrUrl[this.state.version];
-        baseUrl = baseUrl.substr(0, baseUrl.toLowerCase().lastIndexOf(this.state.version.toLowerCase()) - 1);
-        this.setState({baseUrl});
+        var hook = this.getHookType(this.state.cdsUrl);
+        let json_request = buildRequest(request, patient, this.state.ehrUrl, this.state.token, prefetch, this.state.prefetch, hook);
+        const cdsUrl = this.state.cdsUrl;
+        let baseUrl = this.state.baseUrl;
         const jwt = "Bearer " + createJwt(this.state.keypair, baseUrl, cdsUrl);
         console.log(jwt);
         var myHeaders = new Headers({
             "Content-Type": "application/json",
             "authorization": jwt
         });
-        this.consoleLog("Fetching response from " + this.state.cdsUrl[this.state.version], types.info)
+        this.consoleLog("Fetching response from " + this.state.cdsUrl, types.info)
         try {
-            fetch(this.state.cdsUrl[this.state.version], {
+            fetch(this.state.cdsUrl, {
                 method: "POST",
                 headers: myHeaders,
                 body: JSON.stringify(json_request)
@@ -238,6 +218,11 @@ export default class RequestBuilder extends Component {
                 "display": "Auth Server",
                 "value": this.state.authUrl,
                 "key": "authUrl"
+            },
+            "baseUrl": {
+                "display": "Base EHR",
+                "value": this.state.baseUrl,
+                "key": "baseUrl"
             }
         }
 
@@ -246,8 +231,6 @@ export default class RequestBuilder extends Component {
                 <div className="nav-header">
                     <button className={"launch-button left-button btn btn-class " + (this.state.ehrLaunch ? "active" : "not-active")} onClick={() => this.updateStateElement("ehrLaunch", true)}>EHR Launch</button>
                     <button className={"launch-button right-button btn btn-class " + (!this.state.ehrLaunch ? "active" : "not-active")} onClick={() => this.updateStateElement("ehrLaunch", false)}>Standalone</button>
-                    <button className={"version-button left-button btn btn-class " + (this.state.version === "r4" ? "active" : "not-active")} onClick={() => this.updateStateElement("version", "r4")}>r4</button>
-                    <button className={"version-button right-button btn btn-class " + (this.state.version === "stu3" ? "active" : "not-active")} onClick={() => this.updateStateElement("version", "stu3")}>stu3</button>
                     <button className={"btn btn-class settings " + (this.state.showSettings ? "active" : "not-active")} onClick={() => this.updateStateElement("showSettings", !this.state.showSettings)}><span className="glyphicon glyphicon-cog settings-icon" /></button>
 
                 </div>
@@ -263,14 +246,13 @@ export default class RequestBuilder extends Component {
                     </div>
                     {this.state.showSettings ?
                         <SettingsBox
-                            version={this.state.version}
                             headers={header}
-                            updateCB={this.updateVersionedStateElement}
+                            updateCB={this.updateStateElement}
                         /> : null}
                     <div>
                         {/*for the ehr launch */}
                         <RequestBox
-                            ehrUrl={this.state.ehrUrl[this.state.version]}
+                            ehrUrl={this.state.ehrUrl}
                             submitInfo={this.submit_info}
                             access_token={this.state.token}>
 
@@ -303,7 +285,7 @@ export default class RequestBuilder extends Component {
                         patientId={this.state.patient.id}
                         ehrLaunch={true}
                         fhirServerUrl={this.state.baseUrl}
-                        fhirVersion={this.state.version} />
+                        fhirVersion={'r4'} />
                 </div>
 
             </div>

--- a/src/containers/RequestBuilder.js
+++ b/src/containers/RequestBuilder.js
@@ -74,7 +74,7 @@ export default class RequestBuilder extends Component {
             this.setState({ token })
         }).catch((error) =>{
             // fails when keycloak isn't running, add dummy token
-            this.setState({ token: {access_token: "-"}})
+            this.setState({ token: {access_token: ""}})
         })
     }
 

--- a/src/properties.json
+++ b/src/properties.json
@@ -3,11 +3,9 @@
   "client": "app-login",
   "auth": "http://localhost:8180/auth",
   "server": "http://localhost:8090",
-  "ehr_server": "http://localhost:8080/test-ehr/r4/",
+  "ehr_server": "http://localhost:8080/test-ehr/r4",
+  "ehr_base": "http://localhost:8080/test-ehr/r4",
   "cds_service":"http://localhost:8090/r4/cds-services/order-sign-crd",
-  "ehr_server_stu3":"http://localhost:8080/test-ehr/stu3/",
-  "cds_service_stu3": "http://localhost:8090/stu3/cds-services/order-sign-crd",
-  "true_base": "http://localhost:8080/test-ehr",
   "user": "user1",
   "password": "password",
   "public_keys": "http://localhost:3001/public_keys"

--- a/src/util/buildRequest.js
+++ b/src/util/buildRequest.js
@@ -1,5 +1,5 @@
 
-function buildR4Request(request, patient, ehrUrl, token, prefetch, includePrefetch, hook) {    
+export default function buildRequest(request, patient, ehrUrl, token, prefetch, includePrefetch, hook) {    
     const r4json = {
         "hookInstance": "d1577c69-dfbe-44ad-ba6d-3e05e953b2ea",
         "fhirServer": ehrUrl.r4,
@@ -75,67 +75,4 @@ function buildR4Request(request, patient, ehrUrl, token, prefetch, includePrefet
     console.log(r4json);
     console.log("--------- r4");
     return r4json;
-}
-
-function buildStu3Request(request, patient, ehrUrl, token, prefetch, includePrefetch, hook) {    
-    const stu3json = {
-        "hook": hook,
-        "hookInstance": "63d7d1fa-9469-4c44-a5f7-76a129e30967",
-        "fhirServer": ehrUrl.stu3,
-        "fhirAuthorization": null,
-        "user": "Practitioner/1234",
-        "context": {
-          "patientId": patient.id,
-          "encounterId": null,
-          "services": null
-        }
-    };
-
-    if (hook == "order-review") {
-        stu3json.context.orders = {
-            "resourceType": "Bundle",
-            "entry": [
-                request
-            ]
-        }
-    } else if (hook == "order-select") {
-        stu3json.context.draftOrders = {
-            "resourceType": "Bundle",
-            "entry": [
-                request
-            ]
-        }
-        stu3json.context.selections = [
-            request.resourceType + "/" + request.id
-        ]
-    } else if (hook == "order-sign") {
-        stu3json.context.draftOrders = {
-            "resourceType": "Bundle",
-            "entry": [
-                request
-            ]
-        }
-    }
-
-    if (includePrefetch) {
-        stu3json.prefetch = {
-            "deviceRequestBundle":{
-                "resourceType": "Bundle",
-                "type": "collection",
-                "entry": prefetch
-            }
-        }
-    }
-
-    console.log(stu3json);
-    console.log("--------- stu3");
-    return stu3json;
-}
-
-export default function buildRequest(request, patient, ehrUrl, token, prefetch, version, includePrefetch, hook) {
-    if (version==="stu3") {
-        return buildStu3Request(request, patient, ehrUrl, token, prefetch, includePrefetch, hook);
-    } else if (version==="r4") {
-        return buildR4Request(request, patient, ehrUrl, token, prefetch, includePrefetch, hook);
-    }
 }

--- a/src/util/buildRequest.js
+++ b/src/util/buildRequest.js
@@ -11,21 +11,21 @@ export default function buildRequest(request, patient, ehrUrl, token, prefetch, 
             "scope": "patient/Patient.read patient/Observation.read",
             "subject": "cds-service4"
         },
-        "user": "Practitioner/example",
         "context": {
+            "userId": "Practitioner/example",
             "patientId": patient.id,
             "encounterId": "enc89284"
         }
     };
 
-    if (hook == "order-review") {
+    if (hook === "order-review") {
         r4json.context.orders = {
             "resourceType": "Bundle",
             "entry": [
                 request
             ]
         }
-    } else if (hook == "order-select") {
+    } else if (hook === "order-select") {
         r4json.context.draftOrders = {
             "resourceType": "Bundle",
             "entry": [
@@ -35,7 +35,7 @@ export default function buildRequest(request, patient, ehrUrl, token, prefetch, 
         r4json.context.selections = [
             request.resourceType + "/" + request.id
         ]
-    } else if (hook == "order-sign") {
+    } else if (hook === "order-sign") {
         r4json.context.draftOrders = {
             "resourceType": "Bundle",
             "entry": [

--- a/src/util/data.js
+++ b/src/util/data.js
@@ -11,26 +11,17 @@ const types = {
 const headers = {
     "ehrUrl": {
         "display": "EHR Server",
-        "value": {
-            "r4":config.ehr_server,
-            "stu3":config.ehr_server_stu3
-        },
+        "value": config.ehr_server,
         "key": "ehrUrl"
     },
     "cdsUrl": {
         "display": "CRD Server",
-        "value": {
-            "r4":config.cds_service,
-            "stu3":config.cds_service_stu3
-        },
+        "value": config.cds_service,
         "key":"cdsUrl"
     },
     "authUrl": {
         "display": "Auth Server",
-        "value": {
-            "r4": config.auth,
-            "stu3": config.auth
-        },
+        "value": config.auth,
         "key": "authUrl"
     }
 }


### PR DESCRIPTION
Solves the major issues with getting the app to work with logica, mainly by doing away with the bad assumptions baked into the app for connecting with our own test EHR.  If you're trying to get it to work with logica, make sure you set up the properties file correctly.  Since the request generator is supposed to simulate the EHR, it doesn't have the ability to get credentials for access to logica's private server.  To make the request generator work correctly, you can change the settings so that the `open` endpoint is the `ehr-server` and the `closed` endpoint is `ehr-base`.  This will let the app fetch the patients from the `open` endpoint but get security information from the `closed` endpoint, which suits our testing needs for now.  

Also patients should now only retrieve device/service/medication requests when the dropdown is clicked on, reducing load times.  