### PR TITLE
fix service/medication request not being updated

### DIFF
--- a/src/components/SMARTBox/PatientBox.js
+++ b/src/components/SMARTBox/PatientBox.js
@@ -314,7 +314,6 @@ export default class SMARTBox extends Component {
       });
     }
 
-    console.log(options);
     let noResults = 'No results found.'
     if(!returned) {
         noResults = 'Loading...';

--- a/src/components/SMARTBox/PatientBox.js
+++ b/src/components/SMARTBox/PatientBox.js
@@ -113,7 +113,7 @@ export default class SMARTBox extends Component {
     }
     if (serviceRequest.performer) {
       if (serviceRequest.performer[0].reference) {
-        fetch(`${this.props.ehrUrl}${serviceRequest.performer[0].reference}`, {
+        fetch(`${this.props.ehrUrl}/${serviceRequest.performer[0].reference}`, {
           method: "GET",
         })
           .then((response) => {
@@ -159,7 +159,7 @@ export default class SMARTBox extends Component {
     }
     if (deviceRequest.performer) {
       if (deviceRequest.performer.reference) {
-        fetch(`${this.props.ehrUrl}${deviceRequest.performer.reference}`, {
+        fetch(`${this.props.ehrUrl}/${deviceRequest.performer.reference}`, {
           method: "GET",
         })
           .then((response) => {
@@ -205,7 +205,7 @@ export default class SMARTBox extends Component {
     }
     if (medicationRequest.requester) {
       if (medicationRequest.requester.reference) {
-        fetch(`${this.props.ehrUrl}${medicationRequest.requester.reference}`, {
+        fetch(`${this.props.ehrUrl}/${medicationRequest.requester.reference}`, {
           method: "GET",
         })
           .then((response) => {
@@ -232,7 +232,6 @@ export default class SMARTBox extends Component {
         flat: true,
       })
       .then((result) => {
-        console.log(result);
         this.setState((prevState) => ({ deviceRequests: result }));
       });
   }
@@ -245,12 +244,7 @@ export default class SMARTBox extends Component {
         flat: true,
       })
       .then((result) => {
-        this.setState((prevState) => ({
-          serviceRequests: {
-            ...prevState.serviceRequests,
-            [patientId]: result,
-          },
-        }));
+        this.setState((prevState) => ({ serviceRequests: result }));
       });
   }
 
@@ -262,12 +256,7 @@ export default class SMARTBox extends Component {
         flat: true,
       })
       .then((result) => {
-        this.setState((prevState) => ({
-          medicationRequests: {
-            ...prevState.medicationRequests,
-            [patientId]: result,
-          },
-        }));
+        this.setState((prevState) => ({ medicationRequests: result }));
       });
   }
   handleRequestChange(e, data) {
@@ -325,6 +314,7 @@ export default class SMARTBox extends Component {
       });
     }
 
+    console.log(options);
     let noResults = 'No results found.'
     if(!returned) {
         noResults = 'Loading...';

--- a/src/components/SMARTBox/PatientBox.js
+++ b/src/components/SMARTBox/PatientBox.js
@@ -232,7 +232,7 @@ export default class SMARTBox extends Component {
         flat: true,
       })
       .then((result) => {
-        this.setState((prevState) => ({ deviceRequests: result }));
+        this.setState({ deviceRequests: result });
       });
   }
 
@@ -244,7 +244,7 @@ export default class SMARTBox extends Component {
         flat: true,
       })
       .then((result) => {
-        this.setState((prevState) => ({ serviceRequests: result }));
+        this.setState({ serviceRequests: result });
       });
   }
 
@@ -256,7 +256,7 @@ export default class SMARTBox extends Component {
         flat: true,
       })
       .then((result) => {
-        this.setState((prevState) => ({ medicationRequests: result }));
+        this.setState({ medicationRequests: result });
       });
   }
   handleRequestChange(e, data) {


### PR DESCRIPTION
some small bugs with service/medication request needed to be fixed.  DeviceRequest had been updated to account for the new request gathering process, but medication/service were not.  Since the patient boxes each handle their own requests now, instead of being passed a list of all requests, the need to mark each request with a patientId as a key is no longer needed.  DeviceRequest was properly updated to reflect this but ServiceRequest and MedicationRequest were still updating the state with patient-specific objects.