### PR TITLE
change patientId

### DIFF
--- a/src/components/DisplayBox/DisplayBox.js
+++ b/src/components/DisplayBox/DisplayBox.js
@@ -180,7 +180,7 @@ retrieveLaunchContext(link, accessToken, patientId, fhirBaseUrl, fhirVersion) {
         "Accept": 'application/json'
       };
       const launchParameters = {
-        patientId: patientId,
+        patient: patientId,
       };
   
       if (link.appContext) {


### PR DESCRIPTION
the display box sends the launch parameters to the EHR's SMART service endpoint.

When launching from logica itself, we don't have control over the launch parameters.  If the key name was `patientIdentification` here, for example, that's exactly what it shows up as in the token.  Epic and Logica both do this part themselves when you launch from their sandbox, as opposed to with our request generator.  

We don't have any control over what launch parameters they send to the service endpoint. 

For posterity:
- In #29 we updated the app to work with logica, which *did not* involve changing the `patientId`, since it was already `patientId` in the request generator.

- The sister [pull request](https://github.com/HL7-DaVinci/test-ehr/commit/aca1beee422170d0d018e7141726bddee9d12685) in the EHR updated the TokenResponse *only*, which was confusingly producing a token with the `patient` key but accepting parameters with the `patientId` key.  This discrepancy was fixed in this pull request.  

- [DTR was updated](https://github.com/HL7-DaVinci/dtr/commit/83880b77a0208fc2be5feb9b5e2ade3e6cb9fd80) to reflect the change, and now searched for `patientId`.  This finally synced up the apps, the EHR now accepted and dispensed `patientId`, instead of accepting `patientId` and producing `patient`.  

- We've now reverted everything back to `patient`, to be compliant with the spec.  The only substantial, non-reverting change here is that the EHR no longer accepts `patientId`, but is consistent and accepts `patient` instead.
