### PR TITLE
build medicationdispense request with insurance info

### DIFF
--- a/src/components/RequestBox/RequestBox.js
+++ b/src/components/RequestBox/RequestBox.js
@@ -379,12 +379,12 @@ export default class RequestBox extends Component {
       },
     });
 
-    let medicationRequestReference = medicationDispense.authorizingPrescription[0].reference;
-
     this.setState({ gatherCount: 1 });
+    // authorizingPrescription reference can't be resolved. 
+    // An issue is opened in fhir client repo: https://github.com/smart-on-fhir/client-js/issues/131
     client
       .request(`MedicationDispense/${medicationDispense.id}`, {
-        resolveReferences: ["performer.0.actor", "authorizingPrescription.0"],
+        resolveReferences: ["performer.0.actor", "authorizingPrescription.0"], 
         graph: false,
         flat: true,
       })
@@ -409,10 +409,11 @@ export default class RequestBox extends Component {
                 this.addReferencesToList(result.data);
               })
               .finally((info) => { this.checkIfGatherCompleted(client, medicationDispense); });
-          } 
+          }
         });
 
         // work around authorizingPrescription reference can not be resolved issue 
+        let medicationRequestReference = medicationDispense.authorizingPrescription[0].reference;
         if (medicationRequestReference) {
           this.state.gatherCount = this.state.gatherCount + 1;
           client

--- a/src/components/RequestBox/RequestBox.js
+++ b/src/components/RequestBox/RequestBox.js
@@ -413,35 +413,37 @@ export default class RequestBox extends Component {
         });
 
         // work around authorizingPrescription reference can not be resolved issue 
-        let medicationRequestReference = medicationDispense.authorizingPrescription[0].reference;
-        if (medicationRequestReference) {
-          this.state.gatherCount = this.state.gatherCount + 1;
-          client
-            .request(medicationRequestReference, {
-              resolveReferences: ["insurance.0"],
-              graph: false,
-              flat: true,
-            })
-            .then((result) => {
-              this.state.gatherCount = this.state.gatherCount + 1;
-              let coverageReference = result.references;
-              Object.keys(coverageReference).forEach((refKey) => {
-                const ref = coverageReference[refKey];
-                if (ref.resourceType === "Coverage") {
-                  client
-                    .request(`Coverage/${ref.id}`, {
-                      resolveReferences: ["payor"],
-                      graph: false,
-                      flat: true,
-                    })
-                    .then((result) => {
-                      this.addReferencesToList(result.references);
-                    })
-                    .finally((info) => { this.checkIfGatherCompleted(client, medicationDispense); });
-                }
-              });
-            })
-            .finally((info) => { this.checkIfGatherCompleted(client, medicationDispense); });
+        if (medicationDispense.authorizingPrescription != undefined && medicationDispense.authorizingPrescription.length > 0) {
+          let medicationRequestReference = medicationDispense.authorizingPrescription[0].reference;
+          if (medicationRequestReference) {
+            this.state.gatherCount = this.state.gatherCount + 1;
+            client
+              .request(medicationRequestReference, {
+                resolveReferences: ["insurance.0"],
+                graph: false,
+                flat: true,
+              })
+              .then((result) => {
+                this.state.gatherCount = this.state.gatherCount + 1;
+                let coverageReference = result.references;
+                Object.keys(coverageReference).forEach((refKey) => {
+                  const ref = coverageReference[refKey];
+                  if (ref.resourceType === "Coverage") {
+                    client
+                      .request(`Coverage/${ref.id}`, {
+                        resolveReferences: ["payor"],
+                        graph: false,
+                        flat: true,
+                      })
+                      .then((result) => {
+                        this.addReferencesToList(result.references);
+                      })
+                      .finally((info) => { this.checkIfGatherCompleted(client, medicationDispense); });
+                  }
+                });
+              })
+              .finally((info) => { this.checkIfGatherCompleted(client, medicationDispense); });
+          }
         }
       })
       .finally((info) => { this.checkIfGatherCompleted(client, medicationDispense); });

--- a/src/components/SMARTBox/PatientBox.js
+++ b/src/components/SMARTBox/PatientBox.js
@@ -257,7 +257,7 @@ export default class SMARTBox extends Component {
     }
     if (medicationDispense.performer) {
       if (medicationDispense.performer[0].actor.reference) {
-        fetch(`${this.props.ehrUrl}${medicationDispense.performer[0].actor.reference}`, {
+        fetch(`${this.props.ehrUrl}/${medicationDispense.performer[0].actor.reference}`, {
           method: "GET",
         })
           .then((response) => {


### PR DESCRIPTION
This PR retrieves MedicationRequest's insurance information for MedicationDispense if it has authorizingPrescription property when building the order-sign request for MedicationDispense. 

To test:
1. using DMEERX-894 branch in CRD and test-ehr repo
2. Select MedicationDispense of azathioprine for the patient pat014
3. Run through the order-sign flow
4. It should work as before