### PR TITLE
[DMEERX-1043] CRD STU2 - Add ability to annotate order with note based on CRD return

### DIFF
--- a/src/components/DisplayBox/DisplayBox.js
+++ b/src/components/DisplayBox/DisplayBox.js
@@ -129,9 +129,6 @@ export default class DisplayBox extends Component{
             client.update(action.resource).then((result) => {
               console.log("suggested action UPDATE result:");
               console.log(result);
-
-              // call into the request builder to resubmit the CRD request with the suggested request
-              this.props.takeSuggestion(result);
             });
 
           } else {


### PR DESCRIPTION
Only update the request on a create, not an update.

Changes must be tested and coordinated between CRD, CDS-Library and crd-request-generator all with the same branch name of annotation-suggestion.

Sending a Hospital Bed DeviceRequest for William Oster will return Documentation Required with links to launch into DTR.
Sending a Hospital Bed DeviceRequest for Theodore Roosevelt will return No Prior Authorization required with a link to "Save Update To EHR". When clicked it'll save an updated device request with a note about the prior authorization. You can load the DeviceRequest from the test-ehr to view the note.