### PR TITLE
Fix Hook draftOrders

### DIFF
--- a/src/util/buildRequest.js
+++ b/src/util/buildRequest.js
@@ -32,7 +32,9 @@ export default function buildRequest(request, patient, ehrUrl, token, prefetch, 
         r4json.context.draftOrders = {
             "resourceType": "Bundle",
             "entry": [
-                request
+                {
+                    "resource": request
+                }
             ]
         }
         r4json.context.selections = [
@@ -42,7 +44,9 @@ export default function buildRequest(request, patient, ehrUrl, token, prefetch, 
         r4json.context.draftOrders = {
             "resourceType": "Bundle",
             "entry": [
-                request
+                {
+                    "resource": request
+                }
             ]
         }
     }


### PR DESCRIPTION
Add needed 'resource' wrapper around the request in the Hook draftOrders.
Issue was found while trying to test prefetch during connectathon.